### PR TITLE
feat(status): add roblox status notifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ ecosystem.config.js
 **/*.db
 **/*.sqlite
 **/*.db-journal
+
+# Project Files
+*.txt

--- a/.swcrc
+++ b/.swcrc
@@ -6,7 +6,7 @@
       "decorators": true,
       "dynamicImport": false
     },
-    "target": "es2021"
+    "target": "es2022"
   },
   "module": {
     "type": "commonjs"

--- a/src/events/PostMessageReact.ts
+++ b/src/events/PostMessageReact.ts
@@ -1,0 +1,14 @@
+import { Message } from "discord.js";
+import { PostEvent } from "../utils/events/PostEvent";
+import { QEvent } from "../utils/events/BaseEvent";
+
+export class PostMessageReact extends PostEvent {
+    public constructor() {
+        super("messageReactionAdd");
+    }
+
+    public execute(client: QEvent.QClient, message: Message) {
+        console.log(`Star this message ${message.content}`);
+        return;
+    }
+}

--- a/src/interactions/status.ts
+++ b/src/interactions/status.ts
@@ -1,0 +1,49 @@
+import { ChannelType, PermissionFlagsBits as Perms, SlashCommandBuilder } from "discord.js";
+import { QInteraction } from "../utils/QInteraction";
+import { setStatusChannel } from "../models/Guild";
+
+export class status extends QInteraction {
+    public constructor() {
+        super(
+            new SlashCommandBuilder()
+                .setName("status")
+                .setDescription("handle the guild notifiers")
+                .setDMPermission(false)
+                .setDefaultMemberPermissions(Perms.Administrator | Perms.ManageChannels | Perms.ManageGuild)
+                .addSubcommand((cmd) =>
+                    cmd
+                        .setName("channel")
+                        .setDescription("sets the status feed channel")
+                        .addChannelOption((opt) =>
+                            opt
+                                .setName("channel")
+                                .setDescription("the channel to post to")
+                                .addChannelTypes(ChannelType.GuildAnnouncement, ChannelType.GuildText)
+                                .setRequired(true)
+                        )
+                )
+        );
+    }
+
+    public async execute(client: QInteraction.Client, interaction: QInteraction.Chat) {
+        const subcommand = interaction.options.getSubcommand();
+        const channelID = interaction.options.getChannel("channel")?.id;
+
+        // Avoiding no guild
+        if (!interaction.guildId) return;
+        if (!channelID) return;
+
+        switch (subcommand) {
+            case "channel":
+                await interaction.deferReply({ ephemeral: true });
+                setStatusChannel(interaction.guildId, channelID)
+                    .then(() => {
+                        interaction.editReply(`Successfully set status feed channel.`);
+                    })
+                    .catch(() => {
+                        interaction.editReply(`Failed to set status feed channel.`);
+                    });
+                break;
+        }
+    }
+}

--- a/src/models/Guild.ts
+++ b/src/models/Guild.ts
@@ -37,6 +37,11 @@ export class Guild extends Model {
     @Column(DataType.STRING)
     rbxReleases?: string | null;
 
+    /* Status */
+    @AllowNull
+    @Column(DataType.STRING)
+    statusFeed?: string | null;
+
     /* Reaction Roles */
     @AllowNull
     @Column(DataType.STRING)
@@ -97,7 +102,8 @@ export async function getGuildChannels(): Promise<Guild[]> {
         where: {
             [Op.or]: {
                 rbxUpdates: { [Op.ne]: null },
-                rbxReleases: { [Op.ne]: null }
+                rbxReleases: { [Op.ne]: null },
+                statusFeed: { [Op.ne]: null }
             }
         }
     });
@@ -109,13 +115,38 @@ export async function getGuildChannels(): Promise<Guild[]> {
  * @param rbxUpdates The roblox update channel ID
  * @param rbxReleases The roblox release channel ID
  */
-export async function setNotifyChannels(guildID: string | number, channelType: notifyChannel, channelID: string | null) {
+export async function setNotifyChannels(
+    guildID: string | number,
+    channelType: notifyChannel,
+    channelID: string | null
+): Promise<boolean> {
     const [guild] = await Guild.findOrCreate({
         where: { guildID: guildID.toString() }
     });
 
     // Setting role
     guild[channelType] = channelID;
+
+    try {
+        await guild.save();
+    } catch (err) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Sets the status feed channel for the specified guild
+ * @param guildID The target guild ID
+ * @param channel The discord channel ID for status posts
+ */
+export async function setStatusChannel(guildID: string | number, channel: string | null): Promise<boolean> {
+    const [guild] = await Guild.findOrCreate({
+        where: { guildID: guildID.toString() }
+    });
+
+    guild.statusFeed = channel;
 
     try {
         await guild.save();

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -51,6 +51,7 @@ const ApiEndpoints = [
             "Inventory API": "https://inventory.roblox.com/",
             "Premium Features API": "https://premiumfeatures.roblox.com/",
             "Roblox Site": "https://www.roblox.com",
+            "Text Filter API": "https://textfilter.roblox.com/",
             "Thumbnails API": "https://thumbnails.roblox.com/",
             "Users API": "https://users.roblox.com/"
         }

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -32,18 +32,24 @@ const ApiEndpoints = [
     {
         system: "Roblox",
         apis: {
-            "2FA": "https://twostepverification.roblox.com/",
-            Avatar: "https://avatar.roblox.com/",
-            Badges: "https://badges.roblox.com/",
-            Contacts: "https://contacts.roblox.com/",
-            Develop: "https://develop.roblox.com/",
-            Economy: "https://economy.roblox.com/",
-            Friends: "https://friends.roblox.com/",
-            GameJoin: "http://gamejoin.roblox.com/",
-            Groups: "https://groups.roblox.com/",
-            Inventory: "https://inventory.roblox.com/",
-            Thumbnails: "https://thumbnails.roblox.com/",
-            Users: "https://users.roblox.com/"
+            "2FA API": "https://twostepverification.roblox.com/",
+            "Account Settings": "https://accountsettings.roblox.com/",
+            "Asset Delivery": "https://assetdelivery.roblox.com/",
+            "Avatar API": "https://avatar.roblox.com/",
+            "Badges API": "https://badges.roblox.com/",
+            "Contacts API": "https://contacts.roblox.com/",
+            "DataStore API": "https://gamepersistence.roblox.com/",
+            "Develop API": "https://develop.roblox.com/",
+            Devforum: "https://devforum.roblox.com",
+            "Economy API": "https://economy.roblox.com/",
+            "Friends API": "https://friends.roblox.com/",
+            "GameJoin API": "http://gamejoin.roblox.com/",
+            "Games API": "http://games.roblox.com/",
+            "Groups API": "https://groups.roblox.com/",
+            "Inventory API": "https://inventory.roblox.com/",
+            "Roblox Site": "https://www.roblox.com",
+            "Thumbnails API": "https://thumbnails.roblox.com/",
+            "Users API": "https://users.roblox.com/"
         }
     }
 ] as Endpoint[];
@@ -91,7 +97,7 @@ const createEmbed = (response: StatusResponse) => {
 
     return new EmbedBuilder()
         .setAuthor({ name: "Blox-it" })
-        .setTitle(`\`${response.Endpoint} API\` is ${Status[status]}.`)
+        .setTitle(`\`${response.Endpoint}\` is ${Status[status]}.`)
         .setDescription(`${response.Endpoint} API ${embedDescription}`)
         .setImage(`https://httpcats.com/${response.StatusCode}.jpg`)
         .setColor(embedColour)

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -35,8 +35,11 @@ const ApiEndpoints = [
             "2FA API": "https://twostepverification.roblox.com/",
             "Account Settings": "https://accountsettings.roblox.com/",
             "Asset Delivery": "https://assetdelivery.roblox.com/",
+            "Auth API": "https://auth.roblox.com/",
             "Avatar API": "https://avatar.roblox.com/",
             "Badges API": "https://badges.roblox.com/",
+            "Billing API": "https://billing.roblox.com/",
+            "Chat API": "https://chat.roblox.com/",
             "Contacts API": "https://contacts.roblox.com/",
             "DataStore API": "https://gamepersistence.roblox.com/",
             "Develop API": "https://develop.roblox.com/",
@@ -46,6 +49,7 @@ const ApiEndpoints = [
             "Games API": "http://games.roblox.com/",
             "Groups API": "https://groups.roblox.com/",
             "Inventory API": "https://inventory.roblox.com/",
+            "Premium Features API": "https://premiumfeatures.roblox.com/",
             "Roblox Site": "https://www.roblox.com",
             "Thumbnails API": "https://thumbnails.roblox.com/",
             "Users API": "https://users.roblox.com/"
@@ -186,7 +190,10 @@ const getHandledResponse = (response: StatusResponse): HandledResponse => {
         Response: response
     };
 
-    if (response.Status === Status.Unknown) handledResponse.ShouldPost = false;
+    if (response.Status === Status.Unknown) {
+        console.log(`Unhandled response from ${response.Endpoint} : ${response.StatusCode}`);
+        handledResponse.ShouldPost = false;
+    }
 
     // Check response times
     if (response.Status === Status.Online) {
@@ -197,12 +204,12 @@ const getHandledResponse = (response: StatusResponse): HandledResponse => {
     // Checking past status
     const historyEntry = EndpointHistory[response.Endpoint];
     if (historyEntry === undefined && response.Status === Status.Online) {
-        EndpointHistory[response.Endpoint] = response.Status;
+        EndpointHistory[response.Endpoint] = handledResponse.Response.Status ?? response.Status;
         handledResponse.ShouldPost = false;
     }
 
     if (historyEntry === response.Status) handledResponse.ShouldPost = false;
-    EndpointHistory[response.Endpoint] = response.Status;
+    EndpointHistory[response.Endpoint] = handledResponse.Response.Status ?? response.Status;
     return handledResponse;
 };
 

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -26,34 +26,82 @@ interface HandledResponse {
 
 type GroupedResponses = Array<Array<StatusResponse>>;
 
-type Endpoint = { system: string; apis: { [name: string]: string } };
+type EndpointData = { base: string };
+type Endpoint = { system: string; apis: { [name: string]: EndpointData } };
 
 const ApiEndpoints = [
     {
         system: "Roblox",
         apis: {
-            "2FA API": "https://twostepverification.roblox.com/",
-            "Account Settings": "https://accountsettings.roblox.com/",
-            "Asset Delivery": "https://assetdelivery.roblox.com/",
-            "Auth API": "https://auth.roblox.com/",
-            "Avatar API": "https://avatar.roblox.com/",
-            "Badges API": "https://badges.roblox.com/",
-            "Billing API": "https://billing.roblox.com/",
-            "Chat API": "https://chat.roblox.com/",
-            "Contacts API": "https://contacts.roblox.com/",
-            "DataStore API": "https://gamepersistence.roblox.com/",
-            "Develop API": "https://develop.roblox.com/",
-            "Economy API": "https://economy.roblox.com/",
-            "Friends API": "https://friends.roblox.com/",
-            "GameJoin API": "http://gamejoin.roblox.com/",
-            "Games API": "http://games.roblox.com/",
-            "Groups API": "https://groups.roblox.com/",
-            "Inventory API": "https://inventory.roblox.com/",
-            "Premium Features API": "https://premiumfeatures.roblox.com/",
-            "Roblox Site": "https://www.roblox.com",
-            "Text Filter API": "https://textfilter.roblox.com/",
-            "Thumbnails API": "https://thumbnails.roblox.com/",
-            "Users API": "https://users.roblox.com/"
+            "2FA API": {
+                base: "https://twostepverification.roblox.com/"
+            },
+            "Account Settings": {
+                base: "https://accountsettings.roblox.com/"
+            },
+            "Asset Delivery": {
+                base: "https://assetdelivery.roblox.com/"
+            },
+            "Auth API": {
+                base: "https://auth.roblox.com/"
+            },
+            "Avatar API": {
+                base: "https://avatar.roblox.com/"
+            },
+            "Badges API": {
+                base: "https://badges.roblox.com/"
+            },
+            "Billing API": {
+                base: "https://billing.roblox.com/"
+            },
+            "Chat API": {
+                base: "https://chat.roblox.com/"
+            },
+            "Contacts API": {
+                base: "https://contacts.roblox.com/"
+            },
+            "DataStore API": {
+                base: "https://gamepersistence.roblox.com/"
+            },
+            "Develop API": {
+                base: "https://develop.roblox.com/"
+            },
+            "Economy API": {
+                base: "https://economy.roblox.com/"
+            },
+            "Friends API": {
+                base: "https://friends.roblox.com/"
+            },
+            "GameJoin API": {
+                base: "http://gamejoin.roblox.com/"
+            },
+            "Games API": {
+                base: "http://games.roblox.com/"
+            },
+            "Groups API": {
+                base: "https://groups.roblox.com/"
+            },
+            "Inventory API": {
+                base: "https://inventory.roblox.com/"
+            },
+            "Premium Features API": {
+                base: "https://premiumfeatures.roblox.com/"
+            },
+            "Roblox Site": {
+                base: "https://www.roblox.com"
+            },
+            "Text Filter API": {
+                base: "https://textfilter.roblox.com/"
+            },
+            "Thumbnails API": {
+                base: "https://thumbnails.roblox.com/"
+            },
+            "Users API": {
+                base: "https://users.roblox.com/"
+            },
+            "Homepage API": {
+                base: "https://apis.roblox.com/product-experimentation-platform/v1/projects/1/layers/PlayerApp.HomePage.UX/values"
+            }
         }
     }
 ] as Endpoint[];
@@ -230,10 +278,10 @@ const getHandledResponse = (response: StatusResponse): HandledResponse => {
  * @param endpointSet The service and its endpoint grouping
  */
 const checkEndpoints = async (client: QClient, endpointSet: Endpoint) => {
-    const results = Object.entries(endpointSet.apis).map(([name, uri]) => {
+    const results = Object.entries(endpointSet.apis).map(([name, endpointData]) => {
         return new Promise<StatusResponse>((resolve, reject) => {
             axios
-                .get(uri)
+                .get(endpointData.base)
                 .then((res) => {
                     resolve({
                         StatusCode: res.status,

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -77,10 +77,9 @@ const isFulfilled = <T>(item: PromiseSettledResult<T>): item is PromiseFulfilled
  * @returns The embedbuilder
  */
 const createEmbed = (response: StatusResponse) => {
-    const status = convertStatusCode(response.StatusCode);
     let embedDescription: string;
     let embedColour: HexColorString;
-    switch (status) {
+    switch (response.Status) {
         case Status.Online:
             embedDescription = "has improved performance.";
             embedColour = "#00FF00";
@@ -101,9 +100,9 @@ const createEmbed = (response: StatusResponse) => {
 
     return new EmbedBuilder()
         .setAuthor({ name: "Blox-it" })
-        .setTitle(`\`${response.Endpoint}\` is ${Status[status]}.`)
-        .setDescription(`${response.Endpoint} API ${embedDescription}`)
-        .setImage(`https://httpcats.com/${response.StatusCode}.jpg`)
+        .setTitle(`\`${response.Endpoint}\` is ${Status[response.Status ?? 3]}.`)
+        .setDescription(`${response.Endpoint} ${embedDescription}`)
+        .setThumbnail(`https://http.cat/${response.StatusCode}.jpg`)
         .setColor(embedColour)
         .addFields(
             { name: "Response Time", value: `\`\`\`${response.ResponseTime}ms\`\`\``, inline: true },

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -40,7 +40,6 @@ const ApiEndpoints = [
             "Contacts API": "https://contacts.roblox.com/",
             "DataStore API": "https://gamepersistence.roblox.com/",
             "Develop API": "https://develop.roblox.com/",
-            Devforum: "https://devforum.roblox.com",
             "Economy API": "https://economy.roblox.com/",
             "Friends API": "https://friends.roblox.com/",
             "GameJoin API": "http://gamejoin.roblox.com/",
@@ -191,7 +190,8 @@ const getHandledResponse = (response: StatusResponse): HandledResponse => {
 
     // Check response times
     if (response.Status === Status.Online) {
-        response.Status = response.ResponseTime > ResponseTimeThresholdMS ? Status.Degraded : response.Status;
+        handledResponse.Response.Status =
+            response.ResponseTime > ResponseTimeThresholdMS ? Status.Degraded : response.Status;
     }
 
     // Checking past status

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -39,7 +39,7 @@ const EndpointHistory = {} as { [endpoint: string]: Status };
  * Helper method to assert if a set of promises is fulfilled
  * @param item The settled promise result
  */
-const assertFullfilled = <T>(item: PromiseSettledResult<T>): item is PromiseFulfilledResult<T> => {
+const isFulfilled = <T>(item: PromiseSettledResult<T>): item is PromiseFulfilledResult<T> => {
     return item.status === "fulfilled";
 };
 
@@ -204,9 +204,7 @@ const checkEndpoints = async (client: QClient, endpointSet: Endpoint) => {
     });
 
     const settledResults = await Promise.allSettled(results);
-    settledResults
-        .filter(assertFullfilled<[string, StatusResponse]>)
-        .forEach((res) => handleURIStatus(client, ...res.value));
+    settledResults.filter(isFulfilled<[string, StatusResponse]>).forEach((res) => handleURIStatus(client, ...res.value));
 };
 
 /**

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -1,0 +1,191 @@
+import axios, { AxiosError } from "axios";
+import { Module } from "../utils/QModule";
+import { getGuildChannels } from "../models/Guild";
+import { QClient } from "../utils/QClient";
+import { EmbedBuilder, TextChannel } from "discord.js";
+
+enum Status {
+    "Online",
+    "Degraded",
+    "Down",
+    "Unknown"
+}
+
+type Endpoint = { system: string; apis: { [name: string]: string } };
+
+const ApiEndpoints = [
+    {
+        system: "Roblox",
+        apis: {
+            Avatar: "https://avatar.roblox.com/",
+            "2FA": "https://twostepverification.roblox.com/",
+            Thumbnails: "https://thumbnails.roblox.com/",
+            Groups: "https://groups.roblox.com/",
+            Economy: "https://economy.roblox.com/",
+            Develop: "https://develop.roblox.com/"
+        }
+    }
+] as Endpoint[];
+
+const EndpointHistory = {} as { [endpoint: string]: Status };
+
+/**
+ * Helper method to assert if a set of promises is fulfilled
+ * @param item The settled promise result
+ */
+const assertFullfilled = <T>(item: PromiseSettledResult<T>): item is PromiseFulfilledResult<T> => {
+    return item.status === "fulfilled";
+};
+
+const createEmbed = (endpointName: string, status: Status) => {
+    const readableStatus = Status[status];
+    let statusDescriptive: string;
+    switch (status) {
+        case Status.Online:
+            statusDescriptive = "has improved performance.";
+            break;
+        case Status.Degraded:
+            statusDescriptive = "has degraded performance.";
+            break;
+        case Status.Down:
+            statusDescriptive = "is experiencing an outage.";
+            break;
+        default:
+            statusDescriptive = "has unknown status.";
+            break;
+    }
+
+    return new EmbedBuilder()
+        .setTitle(`\`${endpointName} Api\` is ${readableStatus}.`)
+        .setDescription(`${endpointName} ${statusDescriptive}`)
+        .setFooter({ text: "Posted by Blox-it" })
+        .setTimestamp(new Date());
+};
+
+/**
+ * Takes an endpoint name and creates a readable announcement for its status using the Status enum
+ * @param endpointName The name of the endpoint
+ * @param status
+ */
+const announceApiStatus = (client: QClient, endpointName: string, status: Status) => {
+    getGuildChannels()
+        .then((guilds) => {
+            guilds.forEach(async (guildInfo) => {
+                if (!guildInfo.statusFeed) return false;
+
+                // Getting guilds to post in
+                const guild = await client.guilds.fetch(guildInfo.guildID);
+                if (!guild) return false;
+
+                // Finding guild channel
+                const channel = (await guild.channels.fetch(guildInfo.statusFeed)) as TextChannel;
+                if (!channel) return false;
+
+                // Getting role pings
+                // TODO: Add role pings for Degraded, Down, Active states
+
+                // Posting message
+                const message = await channel.send({
+                    embeds: [createEmbed(endpointName, status)]
+                    //allowedMentions: { roles: validatedRoles as string[] }
+                });
+                if (message.crosspostable) message.crosspost();
+            });
+        })
+        .catch(() => {
+            console.log("[StatusMonitor] Failed to getGuildChannels()");
+        });
+};
+
+/**
+ *
+ * @param statusCode
+ * @returns
+ */
+const convertStatusCode = (statusCode: number): Status => {
+    switch (statusCode) {
+        case 200:
+            return Status.Online;
+        case 429:
+            return Status.Degraded;
+        case 500:
+        case 502:
+        case 503:
+        case 504:
+            return Status.Down;
+        default:
+            return Status.Unknown;
+    }
+};
+
+/**
+ * Handles an endpoint name and its status code
+ * @param endpointName The string name of the endpoint
+ * @param statusCode The status code the endpoint returned
+ */
+const handleURIStatus = (client: QClient, endpointName: string, statusCode: number) => {
+    const endpointStatus = convertStatusCode(statusCode);
+    if (endpointStatus === Status.Unknown) return;
+
+    const historyEntry = EndpointHistory[endpointName];
+    if (historyEntry === undefined) {
+        EndpointHistory[endpointName] = endpointStatus;
+        return;
+    }
+
+    if (historyEntry === endpointStatus) return;
+    EndpointHistory[endpointName] = endpointStatus;
+    announceApiStatus(client, endpointName, endpointStatus);
+};
+
+/**
+ * Loops through a specified list of endpoints and verifies against their status code
+ * @param endpointSet The service and its endpoint grouping
+ */
+const checkEndpoints = async (client: QClient, endpointSet: Endpoint) => {
+    const results = Object.entries(endpointSet.apis).map(([name, uri]) => {
+        return new Promise<[string, number]>((resolve, reject) => {
+            axios
+                .get(uri)
+                .then((res) => {
+                    resolve([name, res.status]);
+                })
+                .catch((err: AxiosError) => {
+                    reject([name, err.status]);
+                });
+        });
+    });
+
+    const settledResults = await Promise.allSettled(results);
+    settledResults.filter(assertFullfilled<[string, number]>).forEach((res) => handleURIStatus(client, ...res.value));
+};
+
+/**
+ * Schedules endpoint checking against the specified endpoint set
+ * @param endpointSet The endpoint set to check against
+ * @param time The callback to determine the timeout at each rerun
+ */
+const scheduleEndpointCheck = (client: QClient, endpointSet: Endpoint, time: (setName: string) => number) => {
+    const internalSchedule = async () => {
+        await checkEndpoints(client, endpointSet);
+        setTimeout(internalSchedule, time(endpointSet.system));
+    };
+
+    internalSchedule();
+};
+
+export class StatusMonitor extends Module {
+    constructor(client: QClient) {
+        super({ exportModule: false, autoInit: false });
+
+        client.on("moduleLoaded", (name) => {
+            if (name !== "Database") return;
+            console.log("[StatusMonitor] Initialising");
+            this.init(client);
+        });
+    }
+
+    public async init(client: QClient): Promise<void> {
+        scheduleEndpointCheck(client, ApiEndpoints[0], () => 1000 * 60 * 15); // Check every 15 minutes
+    }
+}

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -3,7 +3,6 @@ import { Module } from "../utils/QModule";
 import { getGuildChannels } from "../models/Guild";
 import { QClient } from "../utils/QClient";
 import { EmbedBuilder, HexColorString, TextChannel } from "discord.js";
-import { start } from "repl";
 
 enum Status {
     "Online",
@@ -241,9 +240,12 @@ export class StatusMonitor extends Module {
             return response;
         });
 
-        // Call init method
-        console.log("[StatusMonitor] Initialising");
-        this.init(client);
+        // Wait for database module to be loaded
+        client.on("moduleLoaded", (name) => {
+            if (name !== "Database") return;
+            console.log("[StatusMonitor] Initialising");
+            this.init(client);
+        });
     }
 
     public async init(client: QClient): Promise<void> {

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -59,7 +59,7 @@ const ApiEndpoints = [
 
 const EndpointHistory = {} as { [endpoint: string]: Status };
 
-const ResponseTimeThresholdMS = 1250;
+const ResponseTimeThresholdMS = 1000;
 
 /**
  * Helper method to assert if a set of promises is fulfilled

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -32,12 +32,18 @@ const ApiEndpoints = [
     {
         system: "Roblox",
         apis: {
-            Avatar: "https://avatar.roblox.com/",
             "2FA": "https://twostepverification.roblox.com/",
-            Thumbnails: "https://thumbnails.roblox.com/",
-            Groups: "https://groups.roblox.com/",
+            Avatar: "https://avatar.roblox.com/",
+            Badges: "https://badges.roblox.com/",
+            Contacts: "https://contacts.roblox.com/",
+            Develop: "https://develop.roblox.com/",
             Economy: "https://economy.roblox.com/",
-            Develop: "https://develop.roblox.com/"
+            Friends: "https://friends.roblox.com/",
+            GameJoin: "http://gamejoin.roblox.com/",
+            Groups: "https://groups.roblox.com/",
+            Inventory: "https://inventory.roblox.com/",
+            Thumbnails: "https://thumbnails.roblox.com/",
+            Users: "https://users.roblox.com/"
         }
     }
 ] as Endpoint[];

--- a/src/modules/StatusMonitor.ts
+++ b/src/modules/StatusMonitor.ts
@@ -128,7 +128,7 @@ const handleURIStatus = (client: QClient, endpointName: string, statusCode: numb
     if (endpointStatus === Status.Unknown) return;
 
     const historyEntry = EndpointHistory[endpointName];
-    if (historyEntry === undefined) {
+    if (historyEntry === undefined && endpointStatus === Status.Online) {
         EndpointHistory[endpointName] = endpointStatus;
         return;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "emitDecoratorMetadata": true,
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "esModuleInterop": true
     },
     "exclude": [],
     "include": ["src/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node16",
+    "extends": "@tsconfig/node18",
     "compilerOptions": {
         "baseUrl": ".",
         "rootDir": "src",


### PR DESCRIPTION
There are only a few endpoints and I expect this list will need to be expanded upon, but this gets the bare essentials in for the status notifier.

- It will check periodically, every 15 minutes, for a change in status
- It will not log an initial 200 request to prevent cases where the bot goes down and comes back up
- It will log any request that is not labelled as 'Online' (200 OK) and does not match the previous response
- It will post it in a configured channel and crosspost it, if available.