### PR TITLE
fix(notifier): fix left and right quotes not being resolved

### DIFF
--- a/src/modules/SubscribeDevforum.ts
+++ b/src/modules/SubscribeDevforum.ts
@@ -134,7 +134,9 @@ const decodeHTML = (encodedString: string): string => {
         gt: ">",
         amp: "&",
         quot: '"',
-        apos: "'"
+        apos: "'",
+        ldquo: "“",
+        rdquo: "”"
     };
     const translateTags = {
         strong: "**",


### PR DESCRIPTION
`&ldquo;` and `$rdquo;` now resolve to `“` and `”` respectively.